### PR TITLE
add -d CLI flag to daemonize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,36 @@
 # description
 
-`pxalarm` is a simple POSIX sh script that periodically checks a config file and executes commands at specified times.
+`pxalarm` is a simple POSIX sh script that periodically checks a config file and
+executes commands at specified times.
 
 # usage
 
 1. Create a config file at `$XDG_CONFIG_HOME/pxalarm/config` or at `$HOME/.config/pxalarm/config`.
+
 2. Set your alarms in that file with the following format:
+
 ```
 [YYYY-MM-DD HH:mm] command
 ```
-3. Launch the program using the following command. The program will run unattended in the background and check the config file every minute.
+
+3. Launch the program with the following command. It will check the config
+file every minute. The `-d` command-line argument will cause the program to run
+unattended in the background as a daemon. You can also omit `-d` to run it in
+the foreground, if you want to see the logs for example.
+
 ```sh
-pxalarm
+./pxalarm -d
 ```
-**Note**: The program will keep running in the background and checking the config file every minute until stopped.
+
+**Note**: The program will continue to run in the background (if the `-d` flag
+was passed) and check the config file every minute until stopped. You can stop
+it at any time by running `pkill pxalarm`, or by pressing Ctrl-C if it is
+running in the foreground.
 
 # config file
 
-Time can be replaced with * to not check that part. The following formats are supported:
+Time can be replaced with * to match any time. The following formats are
+supported:
 ```
 [YYYY-MM-DD HH:mm] command           # command will be executed at that specific moment
 [*-MM-DD HH:mm] command              # command will be executed every year at that specific moment.

--- a/pxalarm
+++ b/pxalarm
@@ -13,9 +13,36 @@
 POSIXLY_CORRECT=1
 export POSIXLY_CORRECT
 
-# Run the script headless
-nohup sh -c 'while true; do
+while getopts dh opt 2>/dev/null
+do
+  case "$opt" in
+    d)
+      daemonize=1
+      ;;
+    h)
+      echo "
+Usage: $0 [-dh]
 
+POSIX sh simple alarm
+
+	-d  Daemonize and run in the background
+	-h  Print this help text" >&2
+      exit 0
+      ;;
+    ?)
+      echo "Usage: $0 [-dh]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -n "$daemonize" ]; then
+  nohup "$0" >/dev/null 2>&1 &
+  echo "Alarm daemon started"
+  exit 0
+fi
+
+while true; do
   config_path="${XDG_CONFIG_HOME}/pxalarm/config"
 
   if [ ! -f "$config_path" ]; then
@@ -85,7 +112,4 @@ nohup sh -c 'while true; do
 
   fi
 
-done' > /dev/null 2>&1 &
-
-# Output a message to indicate that the daemon has started
-printf "Alarm daemon started."
+done


### PR DESCRIPTION
Also add help text.

This allows us to avoid putting the bulk of the program in a string as well as ensuring that the daemon will show up in `ps` output as "pxalarm" and not a giant string.